### PR TITLE
Translate the CUBRID Manual Version 10.0 to Korean

### DIFF
--- a/ko/api/cciapi.rst
+++ b/ko/api/cciapi.rst
@@ -2937,8 +2937,8 @@ cci_schema_info
     각 *type* 에 대한 레코드의 구성은 아래 표와 같다.
 
     **타입에 대한 레코드 구성**
-    ## gichoi ## 
-    +------------------------------------------------------------------------- ------------------------------------------+------------------+--------------------+---------------------+
+
+    +--------------------------------------------------------------------------------------------------------------------+------------------+--------------------+---------------------+
     | 타입                                                                                                               | 칼럼 순서        | 칼럼 이름          | 칼럼 타입           |
     +====================================================================================================================+==================+====================+=====================+
     | CCI_SCH_CLASS                                                                                                      | 1                | NAME               | char \*             |
@@ -3005,8 +3005,8 @@ cci_schema_info
     +--------------------------------------------------------------------------------------------------------------------+------------------+--------------------+---------------------+
     | CCI_SCH_CLASS_ATTRIBUTE                                                                                            |                  |                    |                     |
     |                                                                                                                    |                  |                    |                     |
-    | When the attribute of the CCI_SCH_CLASS_ATTRIBUTE column is INSTANCE or SHARED,                                    |                  |                    |                     |
-    | the order and the name values are identical to those of the column of CCI_SCH_ATTRIBUTE.                           |                  |                    |                     |
+    | CCI_SCH_CLASS_ATTRIBUTE 컬럼이 INSTANCE 또는 SHARED의 속성일 경우에						 |                  |                    |                     | 
+    | 순서와 이름 값은 CCI_SCH_ATTRIBUTE의 컬럼과 동일하다.								 |                  |                    |                     |
     +--------------------------------------------------------------------------------------------------------------------+------------------+--------------------+---------------------+
     | CCI_SCH_CLASS_METHOD                                                                                               | 1                | NAME               | char \*             |
     |                                                                                                                    +------------------+--------------------+---------------------+
@@ -3099,15 +3099,11 @@ cci_schema_info
     +--------------------------------------------------------------------------------------------------------------------+------------------+--------------------+---------------------+
     | CCI_SCH_IMPORTED_KEYS                                                                                              | 1                | PKTABLE_NAME       | char \*             |
     |                                                                                                                    |                  |                    |                     |
-    | Used to retrieve primary key columns that are referred by a foreign key column in a given table.                   |                  |                    |                     |
-    | The results are sorted by PKTABLE_NAME and KEY_SEQ.                                                                |                  |                    |                     |
+    | 주어진 테이블의 외래 키 칼럼들이 참조하고 있는 기본 키 칼럼들의 정보를 조회하며					 |                  |                    |                     |
+    | 결과는 PKTABLE_NAME 및 KEY_SEQ 순서로 정렬된다. 									 |                  |                    |                     |
     |                                                                                                                    |                  |                    |                     |
-    | If this type is specified as a parameter, a foreign key table is specified for                                     |                  |                    |                     |
-    | class_name                                                                                                         |                  |                    |                     |
-    | , and                                                                                                              |                  |                    |                     |
-    | NULL                                                                                                               |                  |                    |                     |
-    | is specified for                                                                                                   |                  |                    |                     |
-    | attr_name.                                                                                                         |                  |                    |                     |
+    | 이 타입을 인자로 지정하면, *class_name*\ 에는 외래 키 테이블,							 |                  |                    |                     |
+    | *attr_name*\ 에는 **NULL**\ 을 지정한다.  									 |                  |                    |                     |
     |                                                                                                                    +------------------+--------------------+---------------------+
     |                                                                                                                    | 2                | PKCOLUMN_NAME      | char \*             |
     |                                                                                                                    +------------------+--------------------+---------------------+
@@ -3137,14 +3133,10 @@ cci_schema_info
     +--------------------------------------------------------------------------------------------------------------------+------------------+--------------------+---------------------+
     | CCI_SCH_EXPORTED_KEYS                                                                                              | 1                | PKTABLE_NAME       | char \*             |
     |                                                                                                                    |                  |                    |                     |
-    | Used to retrieve primary key columns that are referred by all foreign key columns.                                 |                  |                    |                     |
-    | The results are sorted by FKTABLE_NAME and KEY_SEQ.                                                                |                  |                    |                     |
-    | If this type is specified as a parameter, a primary key table is specified for                                     |                  |                    |                     |
-    | class_name                                                                                                         |                  |                    |                     |
-    | , and                                                                                                              |                  |                    |                     |
-    | NULL                                                                                                               |                  |                    |                     |
-    | is specified for                                                                                                   |                  |                    |                     |
-    | attr_name.                                                                                                         |                  |                    |                     |
+    | 주어진 테이블의 기본 키 칼럼들을 참조하는 모든 외래 키 칼럼들의 정보를 조회하며, 					 |                  |                    |                     |
+    | 결과는 FKTABLE_NAME 및 KEY_SEQ 순서로 정렬된다.                                       				 | 	            |                    |                     |
+    | 이 타입을 인자로 지정하면, *class_name*\ 에는 기본 키 테이블,							 |                  |                    |                     |
+    | *attr_name*\ 에는 **NULL**\ 을 지정한다.   									 |                  |                    |                     |
     |                                                                                                                    +------------------+--------------------+---------------------+
     |                                                                                                                    | 2                | PKCOLUMN_NAME      | char \*             |
     |                                                                                                                    +------------------+--------------------+---------------------+
@@ -3173,14 +3165,12 @@ cci_schema_info
     |                                                                                                                    | 9                | PK_NAME            | char \*             |
     +--------------------------------------------------------------------------------------------------------------------+------------------+--------------------+---------------------+
     | CCI_SCH_CROSS_REFERENCE                                                                                            | 1                | PKTABLE_NAME       | char \*             |
+    |															 |                  |                    |                     |
+    | 주어진 테이블의 기본 키와 주어진 테이블의 외래 키가 상호 참조하는 경우,     					 |                  |                    |                     |
+    | 해당 외래 키 칼럼들의 정보를 조회하며, 결과는 FKTABLE_NAME 및 KEY_SEQ 순서로 정렬된다.				 |                  |                    |                     |
+    | 이 타입을 인자로 *class_name*\ 에는 기본 키 테이블,  								 |                  |                    |                     |
+    | *attr_name*  에는 외래 키 테이블을 지정한다.   									 |                  |                    |                     |
     |                                                                                                                    |                  |                    |                     |
-    | Used to retrieve foreign key information when primary keys and foreign keys in a given table are cross referenced. |                  |                    |                     |
-    | The results are sorted by FKTABLE_NAME and KEY_SEQ.                                                                |                  |                    |                     |
-    |                                                                                                                    |                  |                    |                     |
-    | If this type is specified as a parameter, a primary key is specified for                                           |                  |                    |                     |
-    | class_name                                                                                                         |                  |                    |                     |
-    | , and a foreign key table is specified for                                                                         |                  |                    |                     |
-    | attr_name.                                                                                                         |                  |                    |                     |
     |                                                                                                                    +------------------+--------------------+---------------------+
     |                                                                                                                    | 2                | PKCOLUMN_NAME      | char \*             |
     |                                                                                                                    +------------------+--------------------+---------------------+

--- a/ko/api/jdbc.rst
+++ b/ko/api/jdbc.rst
@@ -872,24 +872,22 @@ JDBC에서 **LOB** 데이터를 처리하는 인터페이스는 JDBC 4.0 스펙�
 
     칼럼에서 정의한 크기보다 큰 문자열을 **INSERT** / **UPDATE** 하면 문자열이 잘려서 입력된다.
 
-## gichoi start ## 
 setBoolean
 ----------
 
-prepareStatement.setBoolean(1, true) will set
-    * 1 for numeric types
-    * '1' for string types
+prepareStatement.setBoolean(1, true) 는 다음으로 지정된다.
+    * 1 은 numeric 타입을 의미한다.
+    * '1' 은 string 타입을 의미한다.
 
-prepareStatement.setBooelan(1, false) will set
-    * 0 for numeric types
-    * '0' for string types
+prepareStatement.setBooelan(1, false) 는 다음으로 지정된다.
+    * 0 은 numeric 타입을 의미한다.
+    * '0' 은 string 타입을 의미한다.
 
-.. note:: Behavior of legacy versions
+.. note:: 이전 버전에서 동작 방식 
     
-    prepareStatement.setBoolean(1, true) set
-        * as 2008 R4.1, 9.0, 1 of BIT(1) type
-        * as 2008 R4.3, 2008 R4.4, 9.1, 9.2, 9.3, -128 of SHORT type
-## gichoi end ## 
+    prepareStatement.setBoolean(1, true) 은 다음으로 지정된다.
+        * 2008 R4.1, 9.0 에서는 BIT(1) 타입의 1 을 의미한다.
+        * 2008 R4.3, 2008 R4.4, 9.1, 9.2, 9.3 에서는SHORT 타입의 -128 을 의미한다.
 
 .. _jdbc-error-codes:
 

--- a/ko/env.rst
+++ b/ko/env.rst
@@ -212,6 +212,155 @@ Windows에서 특정 포트를 지정하기 번거로운 경우에도 이 방법
 
 각 구분 별 상세 설명은 아래와 같다.
 
+.. _cubrid-basic-ports:
+
+CUBRID 기본 사용 포트
+---------------------
+
+접속 요청을 기다리는(listening) 프로세스들을 기준으로 각 OS 별로 필요한 포트를 정리하면 다음과 같으며, 각 포트는 listener 쪽에서 개방되어야 한다.
+
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+| listener      | requester     | Linux port     | Windows port                                        | 방화벽 포트 설정         | 설명                   |
++===============+===============+================+=====================================================+==========================+========================+
+| cub_broker    | application   | BROKER_PORT    | BROKER_PORT                                         | 개방(open)               | 일회성 연결            |
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+| CAS           | application   | BROKER_PORT    | APPL_SERVER_PORT ~ (APP_SERVER_PORT + CAS 개수 - 1) | 개방                     | 연결 유지              |
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+| cub_master    | CAS           | cubrid_port_id | cubrid_port_id                                      | 개방                     | 일회성 연결            |
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+| cub_server    | CAS           | cubrid_port_id | 임의의 가용 포트                                    | Linux: 개방              | 연결 유지              |
+|               |               |                |                                                     |                          |                        |
+|               |               |                |                                                     | Windows: 프로그램        |                        |
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+| 클라이언트    | cub_server    | ECHO(7)        | ECHO(7)                                             | 개방                     | 주기적 연결            |
+| 장비(*)       |               |                |                                                     |                          |                        |
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+| 서버          | CAS, CSQL     | ECHO(7)        | ECHO(7)                                             | 개방                     | 주기적 연결            |
+| 장비(**)      |               |                |                                                     |                          |                        |
++---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
+
+(*): CAS 또는 CSQL 프로세스가 존재하는 장비
+
+(**): cub_server가 존재하는 장비
+
+.. note:: Windows에서는 CAS가 cub_server에 접근할 때 사용할 포트를 임의로 정하므로 개방할 포트를 정할 수 없다. 따라서 "Windows 방화벽 >  허용되는 프로그램"에 "%CUBRID%\\bin\\cub_server.exe"을 추가해야 한다.
+    
+서버 프로세스(cub_server)와 이에 접속하는 클라이언트 프로세스들(CAS, CSQL) 사이에서 상대 노드가 정상 동작하는지 ECHO(7) 포트를 통해 서로 확인하므로, 방화벽 존재 시 ECHO(7) 포트를 개방해야 한다. ECHO 포트를 서버와 클라이언트 양쪽 다 개방할 수 없는 상황이라면 cubrid.conf의 :ref:`check_peer_alive <check_peer_alive>` 파라미터 값을 none으로 설정한다.
+
+다음은 각 프로세스 간 연결 관계를 나타낸 것이다.
+
+::
+
+     application - cub_broker
+                 -> CAS  -  cub_master
+                         -> cub_server
+
+*   application: 응용 프로세스
+*   cub_broker: 브로커 서버 프로세스. application이 연결할 CAS를 선택하는 역할을 수행.
+*   CAS: 브로커 응용 서버 프로세스. application과 cub_server를 중계.
+*   cub_master: 마스터 프로세스. CAS가 연결할 cub_server를 선택하는 역할을 수행.
+*   cub_server: DB 서버 프로세스
+
+프로세스 간 관계 기호 및 의미는 다음과 같다.
+
+*   \- 기호: 최초 한 번만 연결됨을 나타낸다.
+*   ->, <- 기호: 연결이 유지됨을 나타내며, -> 의 오른쪽 또는 <-의 왼쪽이 화살을 받는 쪽이다. 화살을 받는 쪽이 처음에 상대 프로세스의 접속을 기다리는(listening) 쪽을 나타낸다.
+*   (master): HA 구성에서 master 노드를 나타낸다.
+*   (slave): HA 구성에서 slave 노드를 나타낸다.
+
+다음은 응용 프로그램과 DB 사이의 연결 과정을 순서대로 나열한 것이다.
+
+#.  application이 cubrid_broker.conf에 설정된 브로커 포트(BROKER_PORT)를 통해 cub_broker와 연결을 시도한다.
+#.  cub_broker는 연결 가능한 CAS를 선택한다.
+#.  application과 CAS가 연결된다. 
+
+    Linux에서는 application이 유닉스 도메인 소켓을 통해 CAS와 연결되므로 BROKER_PORT를 사용한다. Windows에서는 유닉스 도메인 소켓을 사용할 수 없으므로 각 CAS마다 cubrid_broker.conf에 설정된 APPL_SERVER_PORT 값을 기준으로 CAS ID를 더한 포트를 통해 연결된다. APPL_SERVER_PORT의 값이 설정되지 않으면 첫번째 CAS와 연결하는 포트 값은 BROKER_PORT + 1이 된다.
+
+    예를 들어 Windows에서 BROKER_PORT가 33000이고 APPL_SERVER_PORT 가 설정되지 않았으면 application과 CAS 사이에 사용하는 포트는 다음과 같다.
+    
+    *   application이 CAS(1)과 접속하는 포트 : 33001
+    *   application이 CAS(2)와 접속하는 포트 : 33002
+    *   application이 CAS(3)와 접속하는 포트 : 33003
+                
+#.  CAS는 cubrid.conf에 설정된 cubrid_port_id 포트를 통해 cub_master에게 cub_server로의 연결을 요청한다.
+#.  CAS와 cub_server가 연결된다. 
+    
+    Linux에서는 CAS가 유닉스 도메인 소켓을 통해 cub_server와 연결되므로 cubrid_port_id 포트를 사용한다. Windows에서는 유닉스 도메인 소켓을 사용할 수 없으므로 임의의 가용 포트를 통해 cub_server와 연결된다. Windows에서 DB server를 운용한다면 브로커 장비와 DB 서버 장비 사이에서는 임의의 가용 포트를 사용하므로, 두 장비 사이에서 방화벽이 해당 프로세스에 대한 포트를 막게 되면 정상 동작을 보장할 수 없게 된다는 점에 주의한다.
+    
+#.  이후 CAS는 application이 종료되어도 CAS가 재시작되지 않는 한 cub_server와 연결을 유지한다.
+
+.. _cubrid-ha-ports: 
+
+CUBRID HA 사용 포트
+-------------------
+
+CUBRID HA는 Linux 환경에서만 지원한다.
+
+접속 요청을 기다리는(listening) 프로세스들을 기준으로 각 OS 별로 필요한 포트를 정리하면 다음과 같으며, 각 포트는 listener 쪽에서 개방되어야 한다.
+
++------------+---------------+----------------+--------------------------+--------------+
+| listener   | requester     | Linux port     | 방화벽 포트 설정         | 설명         |
++============+===============+================+==========================+==============+
+| cub_broker | application   | BROKER_PORT    | 개방(open)               | 일회성 연결  |
++------------+---------------+----------------+--------------------------+--------------+
+| CAS        | application   | BROKER_PORT    | 개방                     | 연결 유지    |
++------------+---------------+----------------+--------------------------+--------------+
+| cub_master | CAS           | cubrid_port_id | 개방                     | 일회성 연결  |
++------------+---------------+----------------+--------------------------+--------------+
+| cub_master | cub_master    | ha_port_id     | 개방                     | 주기적 연결, |
+|            |               |                |                          | heartbeat    |
+| (slave)    | (master)      |                |                          | 확인         |
++------------+---------------+----------------+--------------------------+--------------+
+| cub_master | cub_master    | ha_port_id     | 개방                     | 주기적 연결, |
+|            |               |                |                          | heartbeat    |
+| (master)   | (slave)       |                |                          | 확인         |
++------------+---------------+----------------+--------------------------+--------------+
+| cub_server | CAS           | cubrid_port_id | 개방                     | 연결 유지    |
++------------+---------------+----------------+--------------------------+--------------+
+| 클라이언트 | cub_server    | ECHO(7)        | 개방                     | 주기적 연결  |
+| 장비(*)    |               |                |                          |              |
++------------+---------------+----------------+--------------------------+--------------+
+| 서버       | CAS, CSQL,    | ECHO(7)        | 개방                     | 주기적 연결  |
+| 장비(**)   | copylogdb,    |                |                          |              |
+|            | applylogdb    |                |                          |              |
++------------+---------------+----------------+--------------------------+--------------+
+    
+(*): CAS, CSQL, copylogdb, 또는 applylogdb 프로세스가 존재하는 장비
+
+(**): cub_server가 존재하는 장비
+
+서버 프로세스(cub_server)와 이에 접속하는 클라이언트 프로세스들(CAS, CSQL, copylogdb, applylogdb 등) 사이에서 상대 노드가 정상 동작하는지 ECHO(7) 포트를 통해 서로 확인하므로, 방화벽 존재 시 ECHO(7) 포트를 개방해야 한다. ECHO 포트를 서버와 클라이언트 양쪽 다 개방할 수 없는 상황이라면 cubrid.conf의 ref:`check_peer_alive <check_peer_alive>` 파라미터 값을 none으로 설정한다.
+
+다음은 각 프로세스 간 연결 관계를 나타낸 것이다.
+
+::
+
+    application - cub_broker
+                -> CAS  -  cub_master(master) <-> cub_master(slave)
+                        -> cub_server(master)     cub_server(slave) <- applylogdb(slave)
+                                              <----------------------- copylogdb(slave)
+                                              
+*   cub_master(master): CUBRID HA 구성에서 master 노드에 있는 마스터 프로세스. 상대 노드가 살아있는지 확인하는 역할을 수행.
+*   cub_master(slave): CUBRID HA 구성에서 slave 노드에 있는 마스터 프로세스. 상대 노드가 살아있는지 확인하는 역할을 수행.
+*   copylogdb(slave): CUBRID HA 구성에서 slave 노드에 있는 복제 로그 복사 프로세스
+*   applylogdb(slave): CUBRID HA 구성에서 slave 노드에 있는 복제 로그 반영 프로세스
+
+master 노드에서 slave 노드로의 복제 과정 파악이 용이하게 하기 위해 위에서 master 노드의 applylogdb, copylogdb와 slave 노드의 CAS는 생략했다.
+
+프로세스 간 관계 기호 및 의미는 다음과 같다.
+
+*   \- 기호: 최초 한 번만 연결됨을 나타낸다.
+*   ->, <- 기호: 연결이 유지됨을 나타내며, -> 의 오른쪽 또는 <-의 왼쪽이 화살을 받는 쪽이다. 화살을 받는 쪽이 처음에 상대 프로세스의 접속을 기다리는(listening) 쪽을 나타낸다.
+*   (master): HA 구성에서 master 노드를 나타낸다.
+*   (slave): HA 구성에서 slave 노드를 나타낸다.
+    
+응용 프로그램과 DB 사이의 연결 과정은 :ref:`cubrid-basic-ports`\ 와 동일하다. 여기에서는 CUBRID HA에 의해 1:1로 master DB와 slave DB를 구성할 때 master 노드와 slave 노드 사이의 연결 과정에 대해서만 설명한다.
+
+#.  cub_master(master)와 cub_master(slave) 사이에는 cubrid_ha.conf에 설정된 ha_port_id를 사용한다.
+#.  copylogdb(slave)는 slave 노드에 있는 cubrid.conf의 cubrid_port_id에 설정된 포트를 통해 cub_master(master)에게 master DB로의 연결을 요청하여, 최종적으로 cub_server(master)와 연결하게 된다.
+#.  applylogdb(slave)는 slave 노드에 있는 cubrid.conf의 cubrid_port_id에 설정된 포트를 통해 cub_master(slave)에게 slave DB로의 연결을 요청하여, 최종적으로 cub_server(slave)와 연결하게 된다.
+
+master 노드에서도 applylogdb와 copylogdb가 동작하는데, master 노드가 절체로 인해 slave 노드로 변경될 때를 대비하기 위함이다.
 
 .. _cwm-cm-ports:
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -3401,9 +3401,6 @@ HA 서비스 운영 중 슬레이브를 새로 추가하려면 기존의 마스�
 복제 불일치 감지 방법
 ---------------------
 
-Replication mismatch between replication nodes, indicating that data of the master node and the slave node is not identical, can be detected to some degree by the following process. You can also use :ref:`cubrid-checksumdb` utility to detect a replication inconsistency. However, please note that there is no more accurate way to detect a replication mismatch than by directly comparing the data of the master node to the data of the slave node. If it is determined that there has been a replication mismatch, you should rebuild the database of the master node to the slave node (see :ref:`rebuilding-replication`.)
-
-
 마스터 노드와 슬레이브 노드의 데이터가 일치하지 않는 복제 노드 간 데이터 불일치 현상은 다음과 같은 과정을 통해 어느 정도 감지할 수 있다. 그러나, 마스터 노드와 슬레이브 노드의 데이터를 서로 직접 비교해보는 방법보다 더 정확한 확인 방법은 없음에 주의해야 한다. 복제 불일치 상태라는 판단이 서면, 마스터 노드의 데이터베이스를 슬레이브 노드에 새로 구축해야 한다(:ref:`rebuilding-replication` 참고).
 
 *   **cubrid statdump** 명령을 수행하여 **Time_ha_replication_delay** 시간을 확인한다. 이 값이 클 수록 복제 지연 정도가 클 수 있다는 것을 의미하며, 지연된 시간만큼 복제 불일치가 존재할 가능성이 커진다.
@@ -3476,58 +3473,59 @@ Replication mismatch between replication nodes, indicating that data of the mast
 checksumdb
 ----------
 
-**checksumdb** provides a simple way to check replication integrity. Basically, it divides each table from a master node into fixed-size chunks and then calculates CRC32 values. The calculation itself, not the calculated value, is then replicated through CUBRID HA. Consequently, by comparing CRC32 values calculated on master and slave nodes, **checksumdb** can report the replication integrity. Note that **checksumdb** might affect master's performance even though it is designed to minimize the performance degradation. ::
+**checksumdb**는 복제 무결성을 확인할 수 있는 간단한 방법을 제공한다. 기본적으로 마스터 노드로부터 각 테이블을 고정된 크기의 chunk로 분할한 후에 CRC32 값으로 계산한다. 이 계산된 값은 CUBRID HA를 통해 복제되며 마스터와 슬레이브 노드에서 CRC32 값을 비교하여 복제 무결성을 알 수 있다. **checksumdb**는 성능 저하를 최소화 하도록 작성되었지만 마스터의 성능에 영향을 끼칠 수 있다.  
 
-        cubrid checksumdb [options] <database-name>@<hostname>
+         cubrid checksumdb [options] <database-name>@<hostname>
 
-.. program:: checksumdb
+ .. program:: checksumdb
 
-*   *<hostname>* : When you initiates checksum calculation, you need to specify the hostname of a master node. When you need to get the result after the calculation is completed, specify the hostname of a node you want to check. 
+ *   *<hostname>* : checksum 계산을 시작하려면 마스터 노드의 호스트명이 필요하다. 또한 확인하려는 특정 노드의 호스트명을 지정해서 계산이 완료된 후의 결과를 확인할 수 있다.
 
-.. option:: -c, --chunk-size=NUMBER
+ .. option:: -c, --chunk-size=NUMBER
 
-    You can specify the number of rows to select for each CRC32 calculation. (default: 500 rows, minimum: 100 rows)
+     각각의 CRC32 계산을 선택하기 위해 특정 개수의 열을 입력할 수 있다. 기본값은 500이며, 최솟값은 100이다.  
 
-.. option:: -s, --sleep=NUMBER
+ .. option:: -s, --sleep=NUMBER
 
-    checksumdb sleeps the specified amount of time after calculating each chunk (default: 100 ms)
-    
-.. option:: -i, --include-class-file=FILE
+     각각의 chunk를 계산한 후에 특정 시간만큼 정지시킬 수 있다. 기본값은 100 ms 이다.
 
-    You can specify tables to check the replication mismatch by specifying the -i FILE option. If it is not specified, entire tables will be checked. Empty string, tab, carriage return and comma are separators among table names in the file.
-    
-.. option:: -e, --exclude-class-file=FILE
+ .. option:: -i, --include-class-file=FILE
 
-    You can specify tables to exclude from checking the replication mismatch by specifying the -e FILE option. Note that either -i or -e can be used, not both.
-    
-.. option:: -t, --timeout=NUMBER
+     -i FILE 옵션을 통해 특정 테이블의 복제 불일치 여부를 확인할 수 있다. 만약 이 옵션이 지정되지 않으면 모든 테이블에 대해서 복제 불일치 여부를 확인한다. 빈 문자열, 탭, 캐리지 리턴과 콤마를 이용해서 파일에서 테이블 이름을 구분할 수 있다.
 
-    You can specify a calculation timeout with this option. (default: 1000 ms) If the timeout is reached, the calculation will be cancelled and will be resumed after a short period of time.
-    
-.. option:: -n, --table-name=STRING
+ .. option:: -e, --exclude-class-file=FILE
 
-    You can specify a table name to save checksum results. (default: db_ha_checksum)
-    
-.. option:: -r, --report-only
+     -e FILE 옵션을 통해 복제 불일치 확인시 특정 테이블을 제외시킬 수 있다. -i 또는 -e 둘 중 하나만 사용할 수 있다.
 
-    After checksum calculation is completed, you can get a report with this option.
-.. option:: --resume
+ .. option:: -t, --timeout=NUMBER
 
-    When checksum calculation is aborted, you can resume the calculation using this option.
+     이 옵션을 이용해서 계산시 timeout을 지정할 수 있으며, 기본값은 1000 ms 이다. 만약 timeout에 도달할 경우 계산은 중단되며, 잠시 후 다시 시작된다.
 
-.. option:: --schema-only
+ .. option:: -n, --table-name=STRING
 
-    When this option is given, checksumdb does not calculate CRC32 but only check schema of each table
-    
-.. option:: --cont-on-error
-    
-    Without this option, checksumdb halts on errors.
+     checksum 결과를 저장할 특정 테이블을 지정할 수 있다. 기본 테이블은 db_ha_checksum 이다.
 
-The following example shows how to start checksumdb ::
+ .. option:: -r, --report-only
 
-    cubrid checksumdb -c 100 -s 10 testdb@master
+     이 옵션을 통해 checksum 계산이 완료된 후에 결과를 얻을 수 있다.
 
-When no replication mismatch found, ::
+ .. option:: --resume
+
+     checksum 계산이 중지되었을 경우, 이 옵션을 이용해서 다시 실행할 수 있다.
+
+ .. option:: --schema-only
+
+     이 옵션을 이용해서 CRC32 계산을 하지 않고 각 테이블의 스키마를 확인할 수 있다.
+
+ .. option:: --cont-on-error
+
+     이 옵션이 없으면 에러가 발생했을 때 checksumdb가 정지한다.
+
+다음은 checksumdb를 실행하는 예제이다. :: 
+
+     cubrid checksumdb -c 100 -s 10 testdb@master
+
+복제 불일치가 발견되지 않았을 경우 ::
 
     $ cubrid checksumdb -r testdb@slave
     ================================================================
@@ -3535,7 +3533,7 @@ When no replication mismatch found, ::
      report time: 2016-01-14 16:33:30
      checksum table name: db_ha_checksum, db_ha_checksum_schema
     ================================================================
-    
+
     ------------------------
      different table schema
     ------------------------
@@ -3552,7 +3550,7 @@ When no replication mismatch found, ::
     t1              7                       0                       88 / 12 / 5 / 14 (ms)
     t2              7                       0                       96 / 13 / 11 / 15 (ms)
 
-When there is a replication mismatch in table *t1*, ::
+테이블 *t1*에서 복제 불일치가 감지되었을 경우 ::
 
     $ cubrid checksumdb -r testdb@slave
     ================================================================
@@ -3560,6 +3558,7 @@ When there is a replication mismatch in table *t1*, ::
      report time: 2016-01-14 16:35:57
      checksum table name: db_ha_checksum, db_ha_checksum_schema
     ================================================================
+
     ------------------------
      different table schema
     ------------------------
@@ -3578,7 +3577,7 @@ When there is a replication mismatch in table *t1*, ::
     t1              7                       3                       86 / 12 / 5 / 14 (ms)
     t2              7                       0                       93 / 13 / 11 / 15 (ms)
 
-When there is a schema mismatch in table *t1*, ::
+테이블 *t1*에서 스키마 불일치가 감지되었을 경우 ::
 
     $ cubrid checksumdb -r testdb@slave
     ================================================================
@@ -3608,7 +3607,6 @@ When there is a schema mismatch in table *t1*, ::
     --------------------------------------------------------------------------------------
     t1              7                       0                       95 / 13 / 11 / 16 (ms)
     t2              7                       0                       94 / 13 / 11 / 15 (ms)
-
 
 .. _ha-error:
 

--- a/ko/upgrade.rst
+++ b/ko/upgrade.rst
@@ -32,14 +32,8 @@
 *   기존 버전의 로캘을 유지하고 싶은 경우에도 $CUBRID/conf/cubrid_locales.txt 파일에 기존 버전의 로캘을 추가하고 make_locale 스크립트를 실행한 후 createdb 명령 실행 시 기존 로캘을 지정한다.
 
 **DB 마이그레이션**
-## gichoi start ##
-*   Since the DB volume of CUBRID 9.x and earlier versions are not compatible with the DB volume of CUBRID 10.0, it should be migrated with cubrid unloaddb/loaddb utility. For more detail procedure, see :ref:`migration-from-41`.
-*   CUBRID 2008 R3.1 and later don't support GLO and the LOB type replaces the GLO feature. For this reason, applications or schemas that use GLO must be modified to be compatible with LOB.
-## gichoi end ##
 
-*   CUBRID 9.3은 CUBRID 9.2와 DB 볼륨이 호환되므로, DB 마이그레이션 작업이 불필요하다.
-*   CUBRID 9.3은 CUBRID 9.1과 DB 볼륨이 호환되지 않으므로, migrate_91_to_92 유틸리티를 사용하여 DB를 마이그레이션해야 한다. 자세한 절차는 :ref:`migration-from-91` 절을 참고하면 된다.
-*   CUBRID 9.0 Beta, 2008 R4.x 및 그 전의 버전과 DB 볼륨이 호환되지 않으므로, cubrid unloaddb/loaddb 유틸리티를 사용하여 DB를 마이그레이션해야 한다. 자세한 절차는 :ref:`migration-from-41` 절을 참고하면 된다.
+*   CUBRID 10.0은 CUBRID 9.x 및 이전 버전들과 DB 볼륨이 호환되지 않으므로, cubrid unloaddb/loaddb 유틸리티를 이용해서 마이그레이션을 해야 한다. 자세한 절차는 :ref:`migration-from-41`을 참고하면 된다.
 *   CUBRID 2008 R3.1부터 GLO를 지원하지 않으며 LOB 타입이 GLO 기능을 대체하게 되었으므로, GLO를 이용한 응용 및 스키마는 LOB 타입에 맞게 수정해야 한다.
 
 .. note::
@@ -55,79 +49,66 @@
 
 *   Java 저장 함수/프로시저 사용자는 loadjava 명령을 실행하여 Java 클래스를 CUBRID에 로딩해야 한다. :doc:`/sql/jsp`\ 를 참고한다.
 
+CUBRID 9.2/ 9.3에서 CUBRID 10.0으로 업그레이드하기
+--------------------------------------------------
 
-CUBRID 9.2/9.3에서 CUBRID 10.0으로 업그레이드하기
---------------------------------------------
+CUBRID 9.2/9.3 버전 사용자는 CUBRID 10.0 버전을 별도의 디렉터리에 설치한 후 CUBRID 10.0으로 마이그레이션을 수행한다. 또한 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
 
-CUBRID 9.2 버전 사용자는 CUBRID 9.3 버전을 같은 디렉터리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
+.. _db-migrate-to-10:
 
 DB 마이그레이션
 ^^^^^^^^^^^^^^^
 
-9.2와 9.3은 서로 DB 볼륨이 호환되므로 DB 마이그레이션이 불필요하다.
-
-Users who are using versions CUBRID 9.2/9.3 should install 10.0 in the different directory, migrate the databases to 10.0 and modify parameter values in the previous environment configuration file.
-
-.. _db-migrate-to-10:
-
-
-The following table shows how to perform the migration using the reserved word detection script, check_reserved.sql, which is separately distributed from http://ftp.cubrid.org/CUBRID_Engine/10.0.0/Linux/ and the cubrid unloaddb/loaddb utilities. (See :ref:`unloaddb` and :ref:`loaddb`)
+다음 표는 예약어 검출 스크립트(check_reserved.sql)를 이용해서 마이그레이션을 수행하는 방법을 보여준다. check_reserved.sql 스크립트는 http://ftp.cubrid.org/CUBRID_Engine/10.0.0/Linux와 cubrird unloaddb/loaddb 유틸리티에서 별도로 배포된다. (참고 :ref:`unloaddb` and :ref:`loaddb`)
 
 +------------------------------------+-----------------------------------------------+-----------------------------------------------+
-| Step                               | Linux Environment                             | Windows Environment                           |
+| 단계                               | Linux 환경                                    | Windows 환경                                  |   
 +====================================+===============================================+===============================================+
-| Step C1: Stop CUBRID Service       | % cubrid service stop                         | Stop CUBRID Service Tray.                     |
+| 1 단계: CUBRID Service 정지        | % cubrid service stop			     | CUBRID service Tray를 종료한다.		     |
 +------------------------------------+-----------------------------------------------+-----------------------------------------------+
-| Step C2: Execute the reserved      | Execute the following command in the directory where the reserved word detection              |
-|         words detection script     | script is located.                                                                            |
-|                                    |                                                                                               |
-|                                    | Execute migration or identifier modification by checking the detection result                 |
-|                                    | (For the allowable identifier).                                                               |
-|                                    |                                                                                               |
-|                                    |   % csql -S -u dba -i check_reserved.sql testdb                                               |
-+------------------------------------+-----------------------------------------------------------------------------------------------+
-| Step C3: Unload the earlier        | Store the databases.txt file and the configuration files under the conf directory             |
-|          version of the DB         | of the earlier version in a separate directory (C3a).                                         |
-|                                    |                                                                                               |
-|                                    | Execute the cubrid unloaddb utility and store the file generated at this point in a           |
-|                                    | separate directory(C3b).                                                                      |
-|                                    |                                                                                               |
-|                                    |   % cubrid unloaddb -S testdb                                                                 |
-|                                    |                                                                                               |
-|                                    | Delete the existing database (C3c).                                                           |
-|                                    |                                                                                               |
-|                                    |   % cubrid deletedb testdb                                                                    |
-|                                    +-----------------------------------------------+-----------------------------------------------+
-|                                    |                                               | Uninstall the earlier version of CUBRID.      |
+| 2 단계: 예약어 검출 스크립트 실행  | 예약어 검출 스크립트가 위치하는 디렉토리에서 아래 명령을 실행한다.			     |
+|				     | 												     |
+|				     | 검출 결과를 확인하여 마이그레이션 진행 또는 식별자 수정 작업을 진행한다.			     |
+|				     |												     |
+|				     |   % csql -S -u dba -i check_reserved_sql testdb						     |
 +------------------------------------+-----------------------------------------------+-----------------------------------------------+
-| Step C4: Install new version       | See :ref:`install-execute`                                                                    |
-+------------------------------------+-----------------------------------------------------------------------------------------------+
-| Step C5: Database creation and     | Go to the directory where you want to create a database, and create one.                      |
-|          data loading              | At this time, be cautious about locale setting(\*). (c5a)                                     |
+| 3 단계: 기존 버전 DB unload	     | 기존 버전의 databases.txt 및 cnof 디렉토리 내 설정 파일을 별도 디렉토리에 보관한다. (3a)	     |
 |                                    |                                                                                               |
-|                                    |   % cd $CUBRID/databases/testdb                                                               |
+|                                    | Unloaddb 유틸리티를 실행하고 이때 생성된 파일을 별도 디렉토리에 보관한다. (3b)		     |
 |                                    |                                                                                               |
-|                                    |   % cubrid createdb testdb en_US                                                              |
+|                                    |   % cubrid unloaddb -S testdb								     |
 |                                    |                                                                                               |
-|                                    | Execute the cubrid loaddb utility with the stored files in (C3b). (C5b)                       |
+|                                    | 기존 DB를 삭제한다. (3c)  								     |
 |                                    |                                                                                               |
-|                                    |   % cubrid loaddb -s testdb_schema -d testdb_objects -i testdb_indexes testdb                 |
-+------------------------------------+-----------------------------------------------------------------------------------------------+
-| Step C6: Back up the new version   |   % cubrid backupdb -S testdb                                                                 |
-|          of the DB                 |                                                                                               |
+|                                    |   % cubrid deletedb testdb								     |
+|				     +-----------------------------------------------+-----------------------------------------------+
+|				     |                                               | 기존 버전의 CUBRID를 언인스톨한다.	     |
 +------------------------------------+-----------------------------------------------+-----------------------------------------------+
-| Step C7: Configure the CUBRID      | Modify the configuration file.                | Start the service by selecting                |
-|          environment and start     | At this point, partially modify               | CUBRID Service Tray > [Service Start].        |
-|          the CUBRID Service        | the configuration files from the earlier      |                                               |
-|                                    | version stored in step (C3a) to fit the new   | Start the database server from the            |
-|                                    | version.                                      | command prompt.                               |
-|                                    |                                               |                                               |
-|                                    | (For configuring system parameter, see        |   % cubrid server start testdb                |
-|                                    | :ref:`conf-from-41` and :doc:`admin/config`)  |                                               |
-|                                    |                                               |                                               |
-|                                    |   % cubrid service start                      |                                               |
-|                                    |                                               |                                               |
-|                                    |   % cubrid server start testdb                |                                               |
+| 4 단계: 새 버전 설치		     | :ref:`install-execute` 참고								     |
++------------------------------------+-----------------------------------------------------------------------------------------------+
+| 5 단계: 데이터베이스 생성 및 	     | 데이터베이스를 생성할 디렉토리로 이동하여 데이터베이스를 생성한다.			     |
+|	  데이터 로딩 		     | 이때, 로케일 설정에 주의해야 한다(\*). (5a)						     |
+|				     |												     |
+|				     |   % cd $CUBRID/databases/testdb								     |
+|                                    |                                                                                               |
+|				     |   5 cubrid createdb testdb ko_KR.UTF8							     |
+|                                    |                                                                                               |
+|				     | (3b)에서 저장한 파일을 이용하여 cubrid loaddb 유틸리티 실행. (5b)			     |
+|                                    |                                                                                               |
+|				     |   % cubrid loaddb -s testdb_schema -d testdb_objects -i testdb_indexes testdb		     |
++------------------------------------+-----------------------------------------------------------------------------------------------+
+| 6 단계: 새 버전의 DB 백업          | % cubrid backupdb -S testdb								     |
++------------------------------------+-----------------------------------------------+-----------------------------------------------+
+| 7 단계: CUBRID 환경 설정 및	     | 환경 설정 파일을 수정한다. 이때, (3a)에서     | CUBRID Service Tray> [Service Start]를 	     |
+|	  CUBRID Service 시작	     | 보관한 기존 버전의 환경 설정 파일을	     | 선택하여 서비스를 시작한다.		     |
+|				     | 새 버전에 맞게 수정한다.			     | 명령 프롬프트 창에서 DB서버를 구동한다.       |
+|				     | 						     | 						     |
+|				     | (시스템 파라미터 설정은 :ref:`conf-from-41`   |                                               |
+|				     |  및 :doc:`admin/config` 참고)		     |   % cubrid server start testdb		     |
+|				     | 						     |                                               |
+|				     |   % cubrid service start			     |                                               |
+|				     |						     |                                               |
+|				     |   % cubrid server start testdb		     |                                               |
 +------------------------------------+-----------------------------------------------+-----------------------------------------------+
 
 
@@ -136,80 +117,21 @@ The following table shows how to perform the migration using the reserved word d
 
 **cubrid.conf**
 
-*   The minimum size of log_buffer_size is changed from 48KB(3*1page, 16KB=1page) into 2MB(128*1page, 16KB=1page); therefore, this value should be larger than the changed minimum size.
-
-.. _up-from-91:
-
-Upgrading from CUBRID 9.1 to CUBRID 10.0
-----------------------------------------
-
-Users who are using versions CUBRID 9.1 should install 10.0 in the different directory, migrate databases to 10.0 and modify parameter values in the previous environment configuration file.
-
-.. _migration-from-91:
-
-DB migration
-^^^^^^^^^^^^
-
-Please refer :ref:`db-migrate-to-10` for migration steps.
-
-
-
 *   log_buffer_size 최소값이 48KB(3*1page, 16KB=1page)에서 2MB(128*1page, 16KB=1page)로 변경되었으므로, 이 값을 설정한 경우 변경된 최소값보다 크게 설정해야 한다.
 
 .. _up-from-91:
 
-CUBRID 9.1에서 CUBRID 9.3으로 업그레이드하기
+CUBRID 9.1에서 CUBRID 10.0으로 업그레이드하기
 --------------------------------------------
 
-CUBRID 9.1 버전 사용자는 CUBRID 9.3 버전을 같은 디렉터리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
+CUBRID 9.1 버전 사용자는 CUBRID 10.0 버전을 별도의 디렉토리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경
 
 .. _migration-from-91:
 
 DB 마이그레이션
 ^^^^^^^^^^^^^^^
 
-CUBRID 9.1에서 DB를 마이그레이션하는 경우는 "migrate_91_to_92 <db_name>" 명령을 사용하여 다음의 절차대로 수행한다.
-
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| 단계                               | Linux 환경                                  | Windows 환경                                |
-+====================================+=============================================+=============================================+
-| 1 단계: CUBRID Service 종료        | % cubrid service stop                       | CUBRID Service Tray를 종료한다.             |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| 2 단계: 예약어 검출 스크립트 실행  | 예약어 검출 스크립트가 위치하는 디렉터리에서 아래 명령을 실행한다.                        |
-|                                    |                                                                                           |
-|                                    | 검출 결과를 확인하여 마이그레이션 진행 또는 식별자 수정 작업을 진행한다.                  |
-|                                    |                                                                                           |
-|                                    |   % csql -S -u dba -i check_reserved.sql testdb                                           |
-+------------------------------------+-------------------------------------------------------------------------------------------+
-| 3 단계: 기존 버전 DB 백업          | 기존 버전의 databases.txt 및 conf 디렉터리 내 설정 파일을 별도 디렉터리에 보관한다. (3a)  |
-|                                    |                                                                                           |
-|                                    | cubrid backup 유틸리티를 실행하고 이때 생성된 파일을 별도 디렉터리에 보관한다. (3b)       |
-|                                    |                                                                                           |
-|                                    |   % cubrid backupdb -S testdb                                                             |
-|                                    +---------------------------------------------+---------------------------------------------+
-|                                    |                                             | 기존 버전의 CUBRID를 언인스톨한다.          |
-|                                    |                                             |                                             |
-|                                    | 기존 DB 볼륨은 그대로 유지한다.             | 이때, 기존 DB 볼륨은 그대로 유지한다.       |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| 4 단계: 새 버전 설치               | 기존의 설치 위치와 같은 디렉터리에 설치한다. :ref:`install-execute` 절을 참고한다.        |
-|                                    | 이때 cubrid.conf와 cubrid_locales.txt은 9.1과 동일하게 설정하며,                          |
-|                                    | make_locale 스크립트를 반드시 실행한다.                                                   |
-+------------------------------------+-------------------------------------------------------------------------------------------+
-| 5 단계: 데이터베이스 마이그레이션  | 기존 DB 볼륨을 가지고 유틸리티를 실행한다.                                                |
-|                                    |                                                                                           |
-|                                    |   % migrate_91_to_92 testdb                                                               |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| 6 단계: CUBRID 환경 설정 및        | 환경 설정 파일을 수정한다. 이때, (3a)에서   | CUBRID Service Tray> [Service Start]를      |
-|                                    | 보관한 기존 버전의 환경 설정 파일을         | 선택하여 서비스를 시작한다.                 |
-|          CUBRID Service 구동       | 새 버전에 맞게 수정한다.                    | 명령 프롬프트 창에서 DB 서버를 구동한다.    |
-|                                    |                                             |                                             |
-|                                    | (시스템 파라미터 설정은 :ref:`conf-from-91` |                                             |
-|                                    | 및 :doc:`admin/config` 참고)                |   % cubrid server start testdb              |
-|                                    |                                             |                                             |
-|                                    |   % cubrid service start                    |                                             |
-|                                    |                                             |                                             |
-|                                    |   % cubrid server start testdb              |                                             |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
+:ref:`db-migrate-to-10`를 참고하여 마이그레이션을 수행한다.
 
 .. _conf-from-91:
 
@@ -258,74 +180,21 @@ CUBRID 9.1에서 DB를 마이그레이션하는 경우는 "migrate_91_to_92 <db_
 
 .. _up-from-41:
 
-Upgrading From CUBRID 2008 R4.1/R4.3/R4.4 To CUBRID 10.0
---------------------------------------------------------
-
-Users who are using a version of CUBRID 2008 R4.1, R4.3 or R4.4 should install 10.0 in the different directory, migrate databases to 10.0 and modify parameter values in the existing environment configuration file.
-
-
-CUBRID 2008 R4.1/R4.3/R4.4에서 CUBRID 9.3으로 업그레이드하기
+CUBRID 2008 R4.1/R4.3/R4.4에서 CUBRID 10.0으로 업그레이드하기
 ------------------------------------------------------------
 
-CUBRID 2008 R4.1/R4.3/R4.4 버전 사용자는 CUBRID 9.3 버전을 별도의 디렉터리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
+CUBRID 2008 R4.1/R4.3/R4.4 버전 사용자는 CUBRID 10.0 버전을 별도의 디렉터리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
 
 .. _migration-from-41:
 
 DB 마이그레이션
 ^^^^^^^^^^^^^^^
 
-아래는 cubrid unloaddb/loaddb 유틸리티와 http://ftp.cubrid.org/CUBRID_Engine/9.3.0/Linux/\ 에서 별도 배포되는 check_reserved.sql 예약어 검출 스크립트를 이용하여 마이그레이션을 수행하는 방법이다. (매뉴얼의 :ref:`unloaddb`\와 :ref:`loaddb` 참고)
+:ref:`db-migrate-to-10`를 참고하여 마이그레이션을 수행한다.
 
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| 단계                               | Linux 환경                                  | Windows 환경                                |
-+====================================+=============================================+=============================================+
-| C1 단계: CUBRID Service 종료       | % cubrid service stop                       | CUBRID Service Tray를 종료한다.             |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| C2 단계: 예약어 검출 스크립트 실행 | 예약어 검출 스크립트가 위치하는 디렉터리에서 아래 명령을 실행한다.                        |
-|                                    |                                                                                           |
-|                                    | 검출 결과를 확인하여 마이그레이션 진행 또는 식별자 수정 작업을 진행한다.                  |
-|                                    |                                                                                           |
-|                                    |   % csql -S -u dba -i check_reserved.sql testdb                                           |
-+------------------------------------+-------------------------------------------------------------------------------------------+
-| C3 단계: 기존 버전 DB 언로드       | 기존 버전의 databases.txt 및 conf 디렉터리 내 설정 파일을 별도 디렉터리에 보관한다. (C3a) |
-|                                    |                                                                                           |
-|                                    | cubrid unloaddb 유틸리티를 실행하고 이때 생성된 파일을 별도 디렉터리에 보관한다. (C3b)    |
-|                                    |                                                                                           |
-|                                    |   % cubrid unloaddb -S testdb                                                             |
-|                                    |                                                                                           |
-|                                    | 기존 DB를 삭제한다. (C3c)                                                                 |
-|                                    |                                                                                           |
-|                                    |   % cubrid deletedb testdb                                                                |
-+------------------------------------+-------------------------------------------------------------------------------------------+
-| C4 단계: 새 버전 설치              | 설치 방법은 :ref:`install-execute` 절을 참고한다.                                         |
-+------------------------------------+-------------------------------------------------------------------------------------------+
-| C5 단계: DB 생성 및 데이터 로딩    | DB를 생성할 디렉터리로 이동한 후, DB를 생성한다. 이때, 로캘 설정에 주의한다(\*).(C5a)     |
-|                                    |                                                                                           |
-|                                    |   % cd $CUBRID/databases/testdb                                                           |
-|                                    |                                                                                           |
-|                                    |   % cubrid createdb testdb en_US                                                          |
-|                                    |                                                                                           |
-|                                    | (C3b)에서 보관한 파일을 가지고 cubrid loaddb 유틸리티를 실행한다. (C5b)                   |
-|                                    |                                                                                           |
-|                                    |   % cubrid loaddb -s testdb_schema -d testdb_objects -i testdb_indexes testdb             |
-+------------------------------------+-------------------------------------------------------------------------------------------+
-| C6 단계: 새 버전 DB 백업           |   % cubrid backupdb -S testdb                                                             |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
-| C7 단계: CUBRID 환경 설정 및       | 환경 설정 파일을 수정한다. 이때, (C3a)에서  | CUBRID Service Tray> [Service Start]를      |
-|                                    | 보관한 이전 버전의 환경 설정 파일을         | 선택하여 서비스를 시작한다.                 |
-|          CUBRID Service 구동       | 새 버전에 맞게 수정한다.                    | 명령 프롬프트 창에서 DB 서버를 구동한다.    |
-|                                    |                                             |                                             |
-|                                    | (시스템 파라미터 설정은 :ref:`conf-from-41` |                                             |
-|                                    | 및 :doc:`/admin/config` 참고)               |   % cubrid server start testdb              |
-|                                    |                                             |                                             |
-|                                    |   % cubrid service start                    |                                             |
-|                                    |                                             |                                             |
-|                                    |   % cubrid server start testdb              |                                             |
-+------------------------------------+---------------------------------------------+---------------------------------------------+
+(\*): CUBRID 2008 R4.x 이하 버전 사용자는 로캘(언어와 문자셋) 결정에 특히 주의해야 한다. 예를 들어 언어는 ko_KR(한국어)이고 문자셋은 utf8을 사용하던 2008 R4.3 사용자가 10.0 으로 마이그레이션을 진행하는 경우, "cubrid createdb testdb ko_KR.utf8"과 같이 로캘을 지정해야 한다. 지정하려는 로캘이 시스템 내장 로캘이 아닌 경우, 먼저 make_locale(.sh) 명령을 실행해야 한다. :ref:`locale-setting`\ 을 참고한다.
 
-(\*): CUBRID 2008 R4.x 이하 버전 사용자는 로캘(언어와 문자셋) 결정에 특히 주의해야 한다. 예를 들어 언어는 ko_KR(한국어)이고 문자셋은 utf8을 사용하던 2008 R4.3 사용자가 9.3으로 마이그레이션을 진행하는 경우, "cubrid createdb testdb ko_KR.utf8"과 같이 로캘을 지정해야 한다. 지정하려는 로캘이 시스템 내장 로캘이 아닌 경우, 먼저 make_locale(.sh) 명령을 실행해야 한다. :ref:`locale-setting`\ 을 참고한다.
-
-*   멀티바이트 문자에 대한 저장 공간 변화에 주의해야 한다. 예를 들어 2008 R4.3에서 CHAR(6)은 6바이트 CHAR 타입을 의미하지만 9.3에서 CHAR(6)은 6글자 CHAR 타입을 의미한다. utf8 문자셋에서 한글은 한 글자 당 3바이트를 차지하므로, CHAR(6)은 18바이트를 차지한다. 따라서 기존 버전보다 더 많은 디스크 공간을 필요로 한다.
+*   멀티바이트 문자에 대한 저장 공간 변화에 주의해야 한다. 예를 들어 2008 R4.3에서 CHAR(6)은 6바이트 CHAR 타입을 의미하지만 10.0 에서 CHAR(6)은 6글자 CHAR 타입을 의미한다. utf8 문자셋에서 한글은 한 글자 당 3바이트를 차지하므로, CHAR(6)은 18바이트를 차지한다. 따라서 기존 버전보다 더 많은 디스크 공간을 필요로 한다.
 
 *   CUBRID 2008 R4.x 이하 버전에서 utf8 문자셋을 사용했다면, "cubrid createdb" 수행 시 반드시 utf8 문자셋으로 지정해야 한다. 그렇지 않을 경우 검색 또는 문자열 함수가 제대로 동작하지 않는다.
 
@@ -383,22 +252,15 @@ DB 마이그레이션
 
 .. _up-from-40:
 
-Upgrading From CUBRID 2008 R4.0 or Earlier Versions To CUBRID 10.0
-------------------------------------------------------------------
-
-Users who are using versions CUBRID 2008 R4.0 or earlier should install 10.0 in the different directory, migrate databases to 10.0 and modify parameter values in the existing environment configuration file.
-
-CUBRID 2008 R4.0 이하 버전에서 CUBRID 9.3으로 업그레이드하기
+CUBRID 2008 R4.0 이하 버전에서 CUBRID 10.0으로 업그레이드하기
 ------------------------------------------------------------
 
-CUBRID 2008 R4.0 이하 버전 사용자는 CUBRID 9.3 버전을 별도의 디렉터리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
+CUBRID 2008 R4.0 이하 버전 사용자는 CUBRID 10.0 버전을 별도의 디렉터리에 설치한 후 기존의 환경 설정 파일에서 파라미터들의 값을 변경해야 한다.
 
 DB 마이그레이션
 ^^^^^^^^^^^^^^^
 
-Do the same procedures with :ref:`db-migrate-to-10`. If you use GLO classes, you must modify applications and schema in order to use BLOB or CLOB types, since GLO classes are not supported in 2008 R3.1. If this modification is not easy, it is not recommended to perform the migration.
-
-:ref:`up-from-41`\ 의 :ref:`migration-from-41`\ 과 동일한 절차대로 수행한다. 단, CUBRID 2008 3.1 이하 버전의 GLO 클래스 사용자가 마이그레이션하는 경우, CUBRID 2008 R3.1부터는 GLO 클래스를 지원하지 않으므로 BLOB 또는 CLOB 타입을 사용하도록 응용과 스키마를 변경해야 한다. 변경 작업이 용이하지 않다면 마이그레이션을 보류할 것을 권장한다.
+:ref:`migration-from-10`\ 과 동일한 절차대로 수행한다. 단, CUBRID 2008 3.1 이하 버전의 GLO 클래스 사용자가 마이그레이션하는 경우, CUBRID 2008 R3.1부터는 GLO 클래스를 지원하지 않으므로 BLOB 또는 CLOB 타입을 사용하도록 응용과 스키마를 변경해야 한다. 변경 작업이 용이하지 않다면 마이그레이션을 보류할 것을 권장한다.
 
 파라미터 설정
 ^^^^^^^^^^^^^
@@ -457,51 +319,16 @@ Do the same procedures with :ref:`db-migrate-to-10`. If you use GLO classes, you
 HA 환경에서 DB 마이그레이션
 ===========================
 
-CUBRID 2008 R2.2 이상 버전에서 CUBRID 9.3으로 HA 마이그레이션 HA migration from CUBRID 2008 R2.2 or higher to CUBRID 10.0
----------------------------------------------------------------------------------------------------------------------------
+CUBRID 2008 R2.2 이상 버전에서 CUBRID 10.0 으로 HA 마이그레이션
+--------------------------------------------------------------
 
 아래는 브로커, 마스터 DB, 슬레이브 DB를 각각 별도 서버에 구축한 환경에서 현재 서비스를 중지하고 업그레이드를 수행하기 위한 절차이다. 
-
-+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| Step                                                 | Description                                                                                               |
-+======================================================+===========================================================================================================+
-| Steps C1-C6: Perform :ref:`db-migrate-to-10`         | Run the CUBRID upgrade and database migration in the master node, and back up the new version's database. |
-|                                                      | on the master node.                                                                                       |
-|                                                      |                                                                                                           |
-+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| Step C7: Install new version in the slave node       | Delete the previous version of the database from the slave node and install a new version.                |
-|                                                      |                                                                                                           |
-|                                                      | For more information, see :ref:`install-execute`.                                                         |
-+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| Step C8: Restore the backup copy of the master node  | Restore the new database backup copy (testdb_bk*) of the master node, which is created in step H6         |
-|          in the slave node                           | , to the slave node.                                                                                      |
-|                                                      |                                                                                                           |
-|                                                      |   % scp user1\ @master:$CUBRID/databases/databases.txt $CUBRID/databases/.                                |
-|                                                      |                                                                                                           |
-|                                                      |   % cd ~/DB/testdb                                                                                        |
-|                                                      |                                                                                                           |
-|                                                      |   % scp user1\ @master:~/DB/testdb/testdb_bk0v000 .                                                       |
-|                                                      |                                                                                                           |
-|                                                      |   % scp user1\ @master:~/DB/testdb/testdb_bkvinf .                                                        |
-|                                                      |                                                                                                           |
-|                                                      |   % cubrid restoredb testdb                                                                               |
-+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| Step C9: Reconfigure HA environment and start        | In the master node and the slave node, set the CUBRID environment configuration file (cubrid.conf)        |
-|          HA mode                                     | and the HA environment configuration file(cubrid_ha.conf)                                                 |
-|                                                      | See :ref:`quick-server-config`.                                                                           |
-+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
-| Step C10: Install new version in the broker server,  | For more information about installation, see :ref:`install-execute`.                                      |
-|           and start the broker                       |                                                                                                           |
-|                                                      | Start the broker in the Broker server. See :ref:`quick-broker-config`.                                    |
-|                                                      |                                                                                                           |
-|                                                      |   % cubrid broker start                                                                                   |
-+------------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 
 +------------------------------------------------------+--------------------------------------------------------------------------------------------------+
 | 단계                                                 | 설명                                                                                             |
 +======================================================+==================================================================================================+
-| H1~H6 단계: 마스터 노드에서 :ref:`migration-from-91` | 마스터 노드에서 CUBRID 업그레이드 및 DB 마이그레이션을 수행하고, 새 버전의 DB를 백업한다.        |
-| 또는 :ref:`migration-from-41`\ 의 C1~C6 단계를 수행  |                                                                                                  |
+| H1~H6 단계: 마스터 노드에서 :ref:`migration-from-10`\| 마스터 노드에서 CUBRID 업그레이드 및 DB 마이그레이션을 수행하고, 새 버전의 DB를 백업한다.        |
+| 의 C1~C6 단계를 수행 				       |                                                                                                  |
 +------------------------------------------------------+--------------------------------------------------------------------------------------------------+
 | H7 단계: 슬레이브 서버에 CUBRID 새 버전 설치         | 슬레이브 서버에서 기존 버전의 DB는 삭제하고, 새 버전을 설치한다.                                 |
 |                                                      |                                                                                                  |
@@ -530,22 +357,12 @@ CUBRID 2008 R2.2 이상 버전에서 CUBRID 9.3으로 HA 마이그레이션 HA m
 |                                                      |   % cubrid broker start                                                                          |
 +------------------------------------------------------+--------------------------------------------------------------------------------------------------+
 
-CUBRID 2008 R2.0 또는 R2.1에서 CUBRID 9.3으로 HA 마이그레이션 HA Migration from CUBRID 2008 R2.0/R2.1 to CUBRID 10.0
----------------------------------------------------------------------------------------------------------------------
+CUBRID 2008 R2.0 또는 R2.1에서 CUBRID 10.0 으로 HA 마이그레이션
+--------------------------------------------------------------
 
 CUBRID 2008 R2.0 또는 R2.1의 HA 기능을 사용하는 경우, 서버 버전 업그레이드, DB 마이그레이션을 수행하고 HA 환경을 새롭게 구축한 후 해당 버전에서 사용되었던 Linux Heartbeat 자동 시작 설정을 변경해야 한다. (Linux Heartbeat 패키지가 불필요한 경우 삭제한다.)
 
 위의 H1~H10 단계를 수행한 후, 아래의 H11 단계를 수행한다.
-
-+-----------------------------------------------------+-------------------------------------------------------------------------------+
-| Step                                                | Description                                                                   |
-+=====================================================+===============================================================================+
-| Step C11: Change the previous Linux heartbeat       | Perform the following task in the master and slave nodes from a root account. |
-|           auto start settings                       |                                                                               |
-|                                                     |   [root\ @master ~]# chkconfig --del heartbeat                                |
-|                                                     |   // Performing the same job in the slave node                                |
-+-----------------------------------------------------+-------------------------------------------------------------------------------+
-
 
 +-----------------------------------------------------+-------------------------------------------------------------------+
 | 단계                                                | 설명                                                              |


### PR DESCRIPTION
## Allocated part of manual

| part of manual | work result |
| --- | --- |
| en/api/cciapi.rst | complete |
| en/api/cci.rst | nothing to do |
| en/api/jdbc.rst | complete |
| en/conf.py | nothing to do |
| en/csql.rst | nothing to do |
| en/env.rst | complete |
| en/ha.rst | complete |
| en/index.rst | nothing to do |
| en/install.rst | nothing to do |
| en/upgrade.rst | complete |

Please merge the fix after you check this pull request. Thank you. :smile:
