### PR TITLE
Modify invalid order by column name in ntile function

### DIFF
--- a/en/sql/function/analysis_fn.rst
+++ b/en/sql/function/analysis_fn.rst
@@ -1166,7 +1166,7 @@ The NTILE function equally divides the grade based on the number of rows, regard
 
     SELECT name, score, NTILE(5) OVER (ORDER BY score DESC) grade 
     FROM t_score 
-    ORDER BY name;
+    ORDER BY grade;
 
 ::
 


### PR DESCRIPTION
Before query in [ntile](http://www.cubrid.org/manual/10_0/en/sql/function/analysis_fn.html#ntile) function's example was not like manual's result.
Because result was ordered by 'grade' column.
So, I correct that column name.

Please check my full request. Thanks. 😄 